### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/cftemplate/redshift_data_lifecycle_management_cf.json
+++ b/cftemplate/redshift_data_lifecycle_management_cf.json
@@ -469,7 +469,7 @@
             "FunctionName":"csv-DynamoDB-Redshift-data-lc-management-config-writer",
             "Description":"Creates dynamoDB configuration table, if it doesn't exist and writes the redshift data lifecycle management configuration to the DynamoDB table",
             "Handler":"dynamo_writer.lambda_handler",
-            "Runtime":"python3.7",
+            "Runtime":"python3.10",
             "Timeout":900,
             "Role":{
                "Fn::GetAtt":["DynamoDBLambdaExecutionRole","Arn"]},
@@ -515,7 +515,7 @@
             "FunctionName":"RedshiftDataLCManagementProcedureCreation",
             "Description":"Execute DDLs on Redshift",
             "Handler":"redshift_manager.lambda_handler",
-            "Runtime":"python3.7",
+            "Runtime":"python3.10",
             "Timeout":60,
             "Role":{
                "Fn::GetAtt":["RedshiftLambdaExecutionRole","Arn"]},


### PR DESCRIPTION
CloudFormation templates in amazon-redshift-data-lifecycle-manager have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.